### PR TITLE
A few corrections

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,16 +43,16 @@
 			<li>GNU Social</li>
 			<li>PostActiv</li>
 			<li>Hubzilla</li>
-			<li>SocialHome</li>
+			<li>Socialhome</li>
 		</ul>
 	</article>
 	<article>
 		<h1 id=protocols>Social Protocols for a Decentralised Web</h1>
 		<ul>
-			<li>Diaspora* Protocol (Diaspora*, Hubzilla, SocialHome)</li>
-			<li>OStatus (GNU Social, PostActiv, Mastodon, Hubzilla)</li>
+			<li>Diaspora* Protocol (Diaspora*, Hubzilla, Socialhome, Friendica)</li>
+			<li>OStatus (GNU Social, PostActiv, Mastodon, Hubzilla, Friendica)</li>
 			<li>Zot (Hubzilla)</li>
-			<li>ActivityPub (future: Mastodon, SocialHome)</li>
+			<li>ActivityPub (future: Mastodon, Hubzilla, Socialhome)</li>
 		</ul>
 	</article>
 	<article>


### PR DESCRIPTION
* SocialHome should be written as "Socialhome" (I'm the author, also check https://socialhome.network :))
* Friendica was missing from Diaspora protocol and OStatus implementers
* Hubzilla was missing from ActivityPub implementers. Their AP plugin is AFAIK almost done.